### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Model Context Protocol server for fetching web content and processing images. This allows Claude Desktop (or any MCP client) to fetch web content and handle images appropriately.
 
+<a href="https://glama.ai/mcp/servers/@kwp-lab/mcp-fetch">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kwp-lab/mcp-fetch/badge" alt="mcp-fetch MCP server" />
+</a>
+
 ## Quick Start (For Users)
 
 To use this tool with Claude Desktop, simply add the following to your Claude Desktop configuration (`~/Library/Application Support/Claude/claude_desktop_config.json`):


### PR DESCRIPTION
This PR adds a badge for the [mcp-fetch](https://glama.ai/mcp/servers/@kwp-lab/mcp-fetch) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@kwp-lab/mcp-fetch">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@kwp-lab/mcp-fetch/badge" alt="mcp-fetch MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.